### PR TITLE
correct 403 error

### DIFF
--- a/CoinCheck.ts
+++ b/CoinCheck.ts
@@ -340,12 +340,12 @@ class CoinCheck {
     /**
      * 送金ログを取得
      */
-     getSendMoneyLog(): Promise<SendMoneyLog> { return this.apiRequest('/send_money', 'GET', {currency: "BTC"}) }
+     getSendMoneyLog(): Promise<SendMoneyLog> { return this.apiRequest('/send_money?currency=BTC') }
 
     /**
      * 受け取りログを取得
      */
-     getDepositMoneyLog(): Promise<DepositMoneyLog> { return this.apiRequest('/deposit_money', 'GET', {currency: "BTC"}) }
+     getDepositMoneyLog(): Promise<DepositMoneyLog> { return this.apiRequest('/deposit_money?currency=BTC') }
 }
 
 export { CoinCheck, CoinCheckError }


### PR DESCRIPTION
原因が分かったので修正。

### 原因

GET は body に JSON を指定できないので、 currency=BTC はボディではなくクエリパラメタに指定する必要がある。

### CoinCheck社回答（参考）

あまり秘匿すべき内容も含まれていないので原文ママ貼り付け。

```
いつもご利用いただき、誠にありがとうございます。
Coincheckカスタマーサポートでございます。

APIのご利用に際しご不便をお掛けし申し訳ございません。

当該APIに関して、ご申告のエラーが定常的に発生するといった状況は確認できませんでした。
そのため、お客様の指定した内容やプログラムに起因して当該エラーが生じている可能性が高い状況かと存じます。

誠に申し訳ございませんが、APIの実装に関しては弊社からはご案内できかねますので、ご自身で適宜調整のうえ、動作状況をご確認いただくことをご検討くださいますようお願いいたします。

お手数をお掛けしますが、何卒ご確認のほどよろしくお願いいたします。
```

「ご申告のエラーが定常的に発生するといった状況は確認できません」という回答 + CloudFront で アクセス拒否（403）になっているので、CoinCheckのサーバアプリではなくHTTPサーバ側が弾いている可能性があるので、その観点で適当にググったところ [GETにはBody指定しちゃダメ](http://www.dbc-works.org/feedback/entry/2020/11/22#gsc.tab=0) という情報があったので body→query に変更したら通った。
